### PR TITLE
Make String& parameters const String&, use JsonVariantConst::is/as<const char *>()

### DIFF
--- a/esp_uuid.cpp
+++ b/esp_uuid.cpp
@@ -23,7 +23,7 @@ UUID::UUID(const JsonVariantConst& uuid) {
     return;
   }
 
-  fromString(uuid.as<char*>());
+  fromString(uuid.as<const char*>());
 }
 
 bool UUID::operator<(const UUID& rhs) const { return buffer_ < rhs.buffer_; }

--- a/esp_uuid.cpp
+++ b/esp_uuid.cpp
@@ -13,7 +13,7 @@ UUID::UUID() {
   buffer_[8] = (buffer_[8] & 0x3F) | 0x80;
 }
 
-UUID::UUID(String& uuid) : UUID(uuid.c_str()) {}
+UUID::UUID(const String& uuid) : UUID(uuid.c_str()) {}
 
 UUID::UUID(const char* uuid) { fromString(uuid); }
 
@@ -104,7 +104,7 @@ bool UUID::fromString(const char* uuid) {
   }
 }
 
-bool UUID::fromString(String& uuid) { return fromString(uuid.c_str()); }
+bool UUID::fromString(const String& uuid) { return fromString(uuid.c_str()); }
 
 void UUID::clear() {
   memset(buffer_.data(), 0,

--- a/esp_uuid.cpp
+++ b/esp_uuid.cpp
@@ -18,7 +18,7 @@ UUID::UUID(const String& uuid) : UUID(uuid.c_str()) {}
 UUID::UUID(const char* uuid) { fromString(uuid); }
 
 UUID::UUID(const JsonVariantConst& uuid) {
-  if (uuid.isNull() || !uuid.is<char*>()) {
+  if (uuid.isNull() || !uuid.is<const char*>()) {
     clear();
     return;
   }

--- a/esp_uuid.h
+++ b/esp_uuid.h
@@ -28,7 +28,7 @@ class UUID : public Printable {
   /**
    * Construct the UUID from the given string
    */
-  UUID(cosnt String& uuid);
+  UUID(const String& uuid);
 
   /**
    * Construct the UUID from the given JsonVariantConst as a string

--- a/esp_uuid.h
+++ b/esp_uuid.h
@@ -28,7 +28,7 @@ class UUID : public Printable {
   /**
    * Construct the UUID from the given string
    */
-  UUID(String& uuid);
+  UUID(cosnt String& uuid);
 
   /**
    * Construct the UUID from the given JsonVariantConst as a string
@@ -76,7 +76,7 @@ class UUID : public Printable {
    * \param uuid The UUID in string form (Hex 8-4-4-4-12)
    * \return True if it is a valid UUID string
    */
-  bool fromString(String& uuid);
+  bool fromString(const String& uuid);
 
   /**
    * Clears the UUID and makes it invalid


### PR DESCRIPTION
This:

- Makes the `String&` parameter to the constructor and `UUD::fromString()` a `const String&` - this allows xvalues to be passed to them.
- Switches to the `const char *` versions of `JsonVariantConst`'s `is` and `as` functions. The "plain" `char *` versions were removed in ArduinoJson 6.20.

I'm aware that a "proper" library update requires some additional housekeeping in library.json, but I didn't want to make any assumptions in how you'd like to implement that. Of course, I'm happy to take care of the chore if you would be willing to give some directions. 